### PR TITLE
修复不正确的tasks_else位置

### DIFF
--- a/tools/proxy.py
+++ b/tools/proxy.py
@@ -51,7 +51,7 @@ class Yun:
         self.count = self.get_tasks_else_file_count()
 
     def get_tasks_else_file_count(self):
-        tasks_else_path = "./tasks_else"
+        tasks_else_path = "../tasks_else"
         try:
             file_count = len([name for name in os.listdir(tasks_else_path) if os.path.isfile(os.path.join(tasks_else_path, name))])
         except FileNotFoundError:


### PR DESCRIPTION
呃，使用mitmproxy自动化爬取历史跑步数据时存放数据的位置不太对