### PR TITLE
修复 外校账密登录可能失败

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -7,7 +7,8 @@ cipherkeyencrypted = BGfbsG9EkXz5KeCva8E0MisBeS6bhBEDId3VXeIuBoiBMZU0Mosv7PqKsvq
 cipherkey = JXhWGZjmhhXN+nt8nLpNxA==
 md5key = pie0hDSfMRINRXc7s1UIXfkE
 platform = android
-app_edition = 3.4.7
+app_edition = 3.5.1
+school_login_url = appLoginHGD
 school_id = 100
 school_name = 
 

--- a/main.py
+++ b/main.py
@@ -216,7 +216,13 @@ def noTokenLogin():
     print("config中token为空，是否尝试使用账号密码登录？(y/n)")
     LoginChoice = input()
     if LoginChoice == 'y':
-        token,DeviceId,DeviceName,uuid,sys_edition = Login.main()
+        login_result = Login.main()
+        if login_result is None :
+            print("意外返回None，请再试一次")
+            exit()
+
+        token, DeviceId, DeviceName, uuid, sys_edition = login_result
+        # token,DeviceId,DeviceName,uuid,sys_edition = Login.main()
         #TEST CONTENT
         print("是否保存本次登录产生的token和uuid？(y/n)")
         TokenWrite = input()


### PR DESCRIPTION
1.昨天有外校同学咨询我，账密无法登录，抓包看了一下，登录接口的URL因学校不同而不同，目前先在config.ini开辟了一个school_login_url，默认仍然是工大，外校用户通过抓包即可修改；（这里可能需要去引导使用者去抓包填写？）
2.不同学校的登录返回结果有密文或明文JSON，不一定非要解密，于是我新增了根据返回内容判断是否需要解密；
3.当账密错误时，会继续执行解析token，但是登录返回结果中为{"code":500,"msg":"XXX"}，会导致报错，我增加了对结果的判断，如果为500则返回msg信息并exit()，否则再执行解析token流程；
4.修改后发给对方测试，可以账密登录了，但是会出现偶见的返回None解构报错，再运行一次就正常了，于是我在main.py加入了返回结果判断None；
5.修改后工大的账密登录逻辑经测试，仍不受影响；
6.顺便（手欠bushi）提升了一下app_edition，不知道能不能改，应该没事吧🫣。